### PR TITLE
Update ext.campaigner.php on line 706

### DIFF
--- a/third_party/campaigner/ext.campaigner.php
+++ b/third_party/campaigner/ext.campaigner.php
@@ -703,7 +703,7 @@ class Campaigner_ext {
     }
 
     $this->EE->javascript->set_global('campaigner.memberFields',
-      $this->EE->javascript->generate_json($js_member_fields));
+      json_encode($js_member_fields));
 
     $this->EE->javascript->set_global('campaigner.ajaxUrl',
       str_replace(AMP, '&', BASE)


### PR DESCRIPTION
In ExpressionEngine 2.8.1 clicking on the settings button of the Campaigner extension it shows this error:

Fatal error: Call to undefined method EE_Javascript::generate_json() in httpdocs/ee/system/expressionengine/third_party/campaigner/ext.campaigner.php on line 706

and it makes it unusable.

By replacing $this->EE->javascript->generate_json with json_encode it makes it usable again.
